### PR TITLE
Update the path reference in `git/configure` action

### DIFF
--- a/git/configure/action.yaml
+++ b/git/configure/action.yaml
@@ -16,7 +16,7 @@ runs:
   steps:
     - name: Configure git
       shell: bash
-      run: git/configure/git-configure.sh
+      run: ${{ github.action_path }}/git-configure.sh
       env:
         user_name: ${{ inputs.user_name }}
         user_email: ${{ inputs.user_email }}


### PR DESCRIPTION
# Description - Issue #27
Update the path reference to `git-configure.sh` in the `git/configure` action.

## How has the change been Tested?
* Manual testing is performed for the action by running the test workflow

## Checklist
- [x] I have performed a self-review of my code
- [x] My changes generate no new warnings